### PR TITLE
fixed recipe pickled fish

### DIFF
--- a/data/json/items/comestibles.json
+++ b/data/json/items/comestibles.json
@@ -2704,8 +2704,8 @@
         "description" : "This is a serving of crisply brined and canned fish.  Tasty and nutritious.",
         "price" : 250, "//" : "Two charges per jar.",
         "material" : "flesh",
-        "volume" : 2,
-        "charges" : 2,
+        "volume" : 1,
+        "charges" : 1,
         "fun" : 7
     },
     {

--- a/data/json/items/tools.json
+++ b/data/json/items/tools.json
@@ -5893,7 +5893,7 @@
     "description": "This is a sealed glass jar containing pickled fish.  Use to open and eat to enjoy.",
     "price": 700,
     "material": ["glass", "flesh"],
-    "weight": 1770,
+    "weight": 960,
     "volume": 2,
     "bashing": 4,
     "category" : "food",
@@ -5901,7 +5901,7 @@
         "type": "transform",
         "msg": "You open the jar, exposing it to the atmosphere.",
         "target": "fish_pickled",
-		"target_charges": 4,
+		"target_charges": 2,
         "container": "jar_glass"
     }
   },


### PR DESCRIPTION
Given the weights, and uses in other recipes, it looks like someone
tried to fix this previously by changing charges in comestibles.json,
instead of the jar itself.

These changes make it consistent with other food products and should be
what was originally intended.