### PR TITLE
fixed weight and charges

### DIFF
--- a/data/json/items/comestibles.json
+++ b/data/json/items/comestibles.json
@@ -9893,7 +9893,7 @@
         "price" : 0,
         "material" : "hflesh",
         "volume" : 1,
-        "charges" : 2,
+        "charges" : 1,
         "fun" : 6
     },
     {   "type" : "AMMO",

--- a/data/json/items/tools.json
+++ b/data/json/items/tools.json
@@ -5914,7 +5914,7 @@
     "description": "This is sealed glass jar containing pickled human flesh.  Use to open.  You might even enjoy it.",
     "price": 0,
     "material": ["glass", "hflesh"],
-    "weight": 1986,
+    "weight": 1068,
     "volume": 2,
     "bashing": 4,
     "category" : "food",


### PR DESCRIPTION
Given the weights, and uses in other recipes, it looks like someone
tried to fix this previously by changing charges in comestibles.json,
instead of the jar itself.

These changes make it consistent with other food products and should be
what was originally intended.