### PR TITLE
Red Dot Sight Recipe had incorrect tools

### DIFF
--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -363,7 +363,7 @@
     "book_learn": [ [ "manual_electronics", 4 ], [ "textbook_electronics", 4 ] ],
     "using": [ [ "soldering_standard", 20 ], [ "surface_heat", 20 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "toolset", -1 ] ] ],
+    "tools": [ [ [ "mold_plastic", -1 ], [ "toolset", -1 ] ] ],
     "components": [ 
         [ [ "plastic_chunk", 2 ] ],
         [ [ "amplifier", 1 ] ],


### PR DESCRIPTION
#### Summary
```SUMMARY: Mods "Craftable Weapons Pack - Fixed Red Dot Sight recipe"```

#### Purpose of change
an error in the code made it require BOTH Integrated toolset and plastic mold

#### Describe the solution
Now it requires EITHER integrated toolset or plastic mold

#### Describe alternatives you've considered
It's possible it was intended to require both, but IRL the recipe isn't that hard (if you have access to a laser pointer) and based on the layout of the section it seems like it was intended as an Or not an And but had misplaced brackets.

Mod owner can feel free to refuse/revert if my assumption is incorrect.

#### Additional context
Here's example of real makeshift red dot sight: https://www.youtube.com/watch?v=03j7lLSN82s